### PR TITLE
Use SPDX-compatible identifier for Apache 2 License

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
     "type": "git",
     "url": "https://github.com/ForbesLindesay/diff-match-patch.git"
   },
-  "license": "http://www.apache.org/licenses/LICENSE-2.0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
This way, the npm www will show Apache 2 instead of "none"