### PR TITLE
Added support for CRLF (on windows) for patch_fromText

### DIFF
--- a/index.js
+++ b/index.js
@@ -2058,7 +2058,7 @@ diff_match_patch.prototype.patch_fromText = function(textline) {
   if (!textline) {
     return patches;
   }
-  var text = textline.split('\n');
+  var text = textline.split(diff_match_patch.linebreakRegex_);
   var textPointer = 0;
   var patchHeader = /^@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@$/;
   while (textPointer < text.length) {


### PR DESCRIPTION
Extracting a patch on windows using patch_fromText throws an error with the following message:
**Error: Invalid patch string: @@ -5,4 +5,4 @@**
This is because of the carriage returns in Windows.
Solution, was to make use of the appropriate regular expression.
